### PR TITLE
fix set-self

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,7 +6,7 @@ jobs:
       - get: ((repo_name))
         trigger: true
 
-      - set_pipeline: ((repo_name))
+      - set_pipeline: zap-scanner
         file: ((repo_name))/ci/pipeline.yml
         var_files:
           - ((repo_name))/ci/config.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixed to use zap-scanner instead of zap-runner
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

none
