### PR TITLE
fix vars path

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -9,7 +9,7 @@ jobs:
       - set_pipeline: zap-scanner
         file: ((repo_name))/ci/pipeline.yml
         var_files:
-          - ((repo_name))/ci/config.yml
+          - ci/config.yml
 
   - name: scan-all-contexts
     plan:


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix var path to not include full repo path
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
