### PR TITLE
keep jq and remove unused path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,9 @@ RUN apt-get update && \
     python3-pip && \
     pip3 install --no-cache-dir zaproxy && \
     find /zap -xdev -perm /6000 -type f -exec chmod a-s {} + && \
-    apt-get purge -y curl jq python3-pip && \
+    apt-get purge -y python3-pip && \
     apt-get autoremove -y && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man
 
 # Create non-root zap user and set permissions

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -45,15 +45,6 @@ groups:
       - set-self
       - scan-all-contexts
 
-resources:
-  - name: zap-config
-    type: git
-    source:
-      uri: https://github.com/cloud-gov/zap-runner
-      branch: main
-      paths:
-        - ci/zap-config/**
-
   - name: zap-runner
     type: git
     source:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Keep jq
- Remove zap-config resource
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
