### PR TITLE
update Dockerfile for python3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && \
     curl \
     jq \
     python3-pip && \
+    python-is-python3 && \
     pip3 install --no-cache-dir zaproxy && \
     find /zap -xdev -perm /6000 -type f -exec chmod a-s {} + && \
     apt-get purge -y python3-pip && \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Added python_is_python3 dependency to fix issue
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Will need to ensure dependency stays updated
