### PR TITLE
should be path

### DIFF
--- a/ci/tasks/zap-scan.yml
+++ b/ci/tasks/zap-scan.yml
@@ -14,7 +14,7 @@ inputs:
 
 outputs:
   - name: zap-report
-    dir-path: /zap/wrk
+    path: /zap/wrk
 
 params:
   TARGET_CONTEXT: # one of internal, external, pages, unauthenticated


### PR DESCRIPTION
## Changes proposed in this pull request:

- Should have been path not dir-path

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, quick yaml fix
