### PR TITLE
moves config file to the expected directory

### DIFF
--- a/ci/tasks/zap-scan.yml
+++ b/ci/tasks/zap-scan.yml
@@ -31,6 +31,9 @@ run:
 
       CREDS_JSON="$CREDHB_CRED"
 
+      # Copy config file to expected directory
+      mkdir -p /zap/wrk/zap-config && cp ((repo_name))/ci/zap-config/zap.yaml /zap/wrk/zap-config/zap.yaml
+
       # Filter URLs for this context
       mapfile -t URLS < <(
         tail -n +2 ((repo_name))/ci/zap-config/urls.csv | \


### PR DESCRIPTION
## Changes proposed in this pull request:

- config file needs to be in the /zap/wrk directory

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, updating file location
