### PR TITLE
declaring as a volume is necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ VOLUME ["/zap/wrk"]
 RUN mkdir -p /zap/wrk/zap-config \
     && chown -R zap:zap /zap/wrk/zap-config
 
+# Declare it as a volume so runtimes can mount it
+VOLUME ["/zap/wrk/zap-config"]
+
 # Configure environment for ZAP
 ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 \
     PATH=${JAVA_HOME}/bin:/zap:${PATH} \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Need to declare the volume so that the directory can be used at runtime

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, setting volume
