### PR TITLE
create directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,19 +50,12 @@ RUN useradd -u 1000 -m -s /bin/bash zap && \
 # Switch to non-root for runtime
 USER zap
 
-# Ensure the workspace directory exists and is owned by our zap user
-RUN mkdir -p /zap/wrk \
+# Ensure the workspace directory and zap-config directory exists and is owned by our zap user
+RUN mkdir -p /zap/wrk/zap-config \
     && chown -R zap:zap /zap/wrk
 
 # Declare it as a volume so runtimes can mount it
 VOLUME ["/zap/wrk"]
-
-# Ensure the zap-config directory exists and is owned by our zap user
-RUN mkdir -p /zap/wrk/zap-config \
-    && chown -R zap:zap /zap/wrk/zap-config
-
-# Declare it as a volume so runtimes can mount it
-VOLUME ["/zap/wrk/zap-config"]
 
 # Configure environment for ZAP
 ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Create the wrk directory and the zap-config directory at the same time

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, fixing creation of directories for files