### PR TITLE
remove volume command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,6 @@ USER zap
 RUN mkdir -p /zap/wrk/zap-config \
     && chown -R zap:zap /zap/wrk
 
-# Declare it as a volume so runtimes can mount it
-VOLUME ["/zap/wrk"]
-
 # Configure environment for ZAP
 ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 \
     PATH=${JAVA_HOME}/bin:/zap:${PATH} \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes VOLUME command so that the zap-config directory is not overwritten when a volume is mounted to /zap/wrk

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just making sure a directory exists
